### PR TITLE
add status code to lazy response interface

### DIFF
--- a/src/Response/AbstractLazyHttpResponse.php
+++ b/src/Response/AbstractLazyHttpResponse.php
@@ -38,4 +38,9 @@ abstract class AbstractLazyHttpResponse implements LazyResponseInterface
     {
         return $this->headers;
     }
+
+    public function getStatusCode(): int
+    {
+        return $this->getStatus();
+    }
 }

--- a/src/Response/LazyResponseInterface.php
+++ b/src/Response/LazyResponseInterface.php
@@ -9,4 +9,5 @@ namespace Basster\LazyResponseBundle\Response;
  */
 interface LazyResponseInterface
 {
+    public function getStatusCode(): int;
 }


### PR DESCRIPTION
Unfortunately there was no getter for response codes on the interface. I just added one.

To be more consistent over all the classes, the `getStatus()` method in the `AbstractLazyHttpResponse` should be deprecated for the next major version.